### PR TITLE
remove GITHUB_TOKEN from secrets

### DIFF
--- a/workflow-templates/sp-devxp-CI-full.yml
+++ b/workflow-templates/sp-devxp-CI-full.yml
@@ -17,5 +17,4 @@ jobs:
       java_version: "11" # Java version to use for the build
       maven_version: "3.8.2" # Maven version to use for the build
     secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       DATADOG_API_KEY: ${{ secrets.SP_DATADOG_API_KEY }}

--- a/workflow-templates/sp-devxp-CI-quick.yml
+++ b/workflow-templates/sp-devxp-CI-quick.yml
@@ -17,5 +17,4 @@ jobs:
       java_version: "11" # Java version to use for the build
       maven_version: "3.8.2" # Maven version to use for the build
     secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       DATADOG_API_KEY: ${{ secrets.SP_DATADOG_API_KEY }}

--- a/workflow-templates/sp-devxp-CI-release.yml
+++ b/workflow-templates/sp-devxp-CI-release.yml
@@ -21,5 +21,4 @@ jobs:
       java_version: "11" # Java version to use for the build
       maven_version: "3.8.2" # Maven version to use for the build
     secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       DATADOG_API_KEY: ${{ secrets.SP_DATADOG_API_KEY }}


### PR DESCRIPTION
Reusable workflows receive by default access to GITHUB_TOKEN so it is not necessary to be passed as an argument.